### PR TITLE
sklearn-compat 0.1.5 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "sklearn-compat" %}
-{% set version = "0.1.3" %}
+{% set version = "0.1.5" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/sklearn_compat-{{ version }}.tar.gz
-  sha256: 74f8267613249d599aa3a2f2503af32fa51bce0800b1b0b0a57b52354402454e
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace('-', '_') }}-{{ version }}.tar.gz
+  sha256: 1a0c3a2f384100e034def49ee5a6cfe984a826f79d032eb559f10445e012b02c
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
@@ -21,24 +21,29 @@ requirements:
     - pip
   run:
     - python
-    - scikit-learn >=1.2,<1.7
+    - scikit-learn >=1.2,<1.9
 
 test:
   imports:
     - sklearn_compat
+    - sklearn_compat.utils
+  source_files:
+    - tests/
   commands:
     - pip check
+    - pytest -v tests/
   requires:
     - pip
+    - pytest
 
 about:
   home: https://github.com/sklearn-compat/sklearn-compat
-  summary: Ease support for compatible scikit-learn estimators across versions
+  summary: Ease multi-version support for scikit-learn compatible library
   description: |
     This package provides a set of utilities to make scikit-learn estimators
     compatible with different versions of scikit-learn.
   dev_url: https://github.com/sklearn-compat/sklearn-compat
-  doc_url: https://sklearn-compat.readthedocs.io/
+  doc_url: https://sklearn-compat.readthedocs.io
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE


### PR DESCRIPTION
sklearn-compat 0.1.5 

**Destination channel:** Defaults

### Links

- [PKG-11835]
- dev_url:        https://github.com/sklearn-compat/sklearn-compat/tree/0.1.5
- conda_forge:    https://github.com/conda-forge/sklearn-compat-feedstock
- pypi:           https://pypi.org/project/sklearn-compat/0.1.5
- pypi inspector: https://inspector.pypi.io/project/sklearn-compat/0.1.5

### Explanation of changes:

- new version number
- add testing
- add py314 build

Update required by `imbalanced-learn`


[PKG-11835]: https://anaconda.atlassian.net/browse/PKG-11835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ